### PR TITLE
Update CircleCI 'stable' toolchain to 1.26.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   stable:
     docker:
-    - image: rust:1.19.0
+    - image: rust:1.26.0
     environment:
       RUSTFLAGS: -D warnings
     working_directory: ~/build


### PR DESCRIPTION
This updates the 'stable' CI job to use rustc 1.26.0, which fixes the CI failures in #12 and #13.

Prior to 1.26.0, Rust would not automatically implement `Clone` for suitable closures, meaning that many iterator adapters cannot be `Clone`. The tests added in #12 and #13 rely on being able to clone certain iterators.

**Obsolete description follows. Branch no longer includes extraneous changes.**

BEWARE: This PR includes the changes from #13, so that I can verify that updating the CI rustc fixes the failures. Please don't merge this as-is, since updating CI and merging the PR are separate decisions.

(Maybe there are less confusing ways to go about this, and I just lack the GitHub/CircleCI-fu to recognize them. Please let me know!)