### PR TITLE
Remove FromFailableIterator trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* `FromFallibleIterator` trait is removed, `FallibleIterator::collect` now requires `std::iter::FromIterator`,
+  which has strictly more implementations.
+
 ## [v0.2.0] - 2019-03-10
 
 ### Changed


### PR DESCRIPTION
We can use std::iter::FromIterator instead, which has the advantage of
working with more types out of the box. It also tightens up the
semantics a little bit, because it forbids swallowing an error.

That's just a proof of concept PR. If you are ok with the change in general, I can remove the trait completely. 