### PR TITLE
Add from_fn(), corresponding to std::iter::from_fn()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1887,6 +1887,52 @@ where
     }
 }
 
+/// Creates an iterator from a fallible function generating values
+///
+/// ```
+/// # use fallible_iterator::{from_fn, FromFallibleIterator, FallibleIterator};
+/// let mut count = 0;
+/// let counter = from_fn(move || {
+///     // Increment our count. This is why we started at zero.
+///     count += 1;
+///
+///     // Check to see if we've finished counting or not.
+///     if count < 6 {
+///         Ok(Some(count))
+///     } else if count < 7 {
+///         Ok(None)
+///     } else {
+///         Err(())
+///     }
+/// });
+/// assert_eq!(&counter.collect::<Vec<_>>().unwrap(), &[1, 2, 3, 4, 5]);
+/// ```
+#[inline]
+pub fn from_fn<I, E, F>(fun: F) -> FromFn<F>
+where
+    F: FnMut() -> Result<Option<I>, E>,
+{
+    FromFn { fun }
+}
+
+/// An iterator using a function to generate new values.
+#[derive(Clone, Debug)]
+pub struct FromFn<F> {
+    fun: F,
+}
+
+impl<I, E, F> FallibleIterator for FromFn<F>
+where
+    F: FnMut() -> Result<Option<I>, E>,
+{
+    type Item = I;
+    type Error = E;
+
+    fn next(&mut self) -> Result<Option<I>, E> {
+        (self.fun)()
+    }
+}
+
 /// An iterator that yields `Ok(None)` forever after the underlying iterator
 /// yields `Ok(None)` once.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This function enables construction from a method returning
`Result<Option<_>, _`. The same can be achieved through using
`convert(std::iter::from_fn())` but the function could then not use `?` for
error-handling.