### PR TITLE
Refactor: tidy up imports and features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
     - run: rustc --version > ~/rust-version
     - *RESTORE_DEPS
     - run: cargo test
-    - run: cargo test --features std
     - *SAVE_DEPS
   nightly:
     docker:
@@ -49,7 +48,7 @@ jobs:
     - *SAVE_REGISTRY
     - run: rustc --version > ~/rust-version
     - *RESTORE_DEPS
-    - run: cargo test --features alloc
+    - run: cargo test
     - *SAVE_DEPS
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   stable:
     docker:
-    - image: rust:1.33.0
+    - image: rust:1.36.0
     environment:
       RUSTFLAGS: -D warnings
     working_directory: ~/build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,5 @@ readme = "README.md"
 categories = ["algorithms", "no-std"]
 
 [features]
+default = ["alloc"]
 alloc = []
-std = []
-default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,7 @@ use core::{
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
-pub use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use alloc::boxed::Box;
 
 #[cfg(all(test, feature = "alloc"))]
 mod test;
@@ -229,7 +225,7 @@ pub trait FallibleIterator {
         Self: Sized,
         F: FnMut(Self::Item) -> Result<B, Self::Error>,
     {
-        Map { it: self, f: f }
+        Map { it: self, f }
     }
 
     /// Calls a fallible closure on each element of an iterator.
@@ -251,7 +247,7 @@ pub trait FallibleIterator {
         Self: Sized,
         F: FnMut(&Self::Item) -> Result<bool, Self::Error>,
     {
-        Filter { it: self, f: f }
+        Filter { it: self, f }
     }
 
     /// Returns an iterator which both filters and maps. The closure may fail;
@@ -262,7 +258,7 @@ pub trait FallibleIterator {
         Self: Sized,
         F: FnMut(Self::Item) -> Result<Option<B>, Self::Error>,
     {
-        FilterMap { it: self, f: f }
+        FilterMap { it: self, f }
     }
 
     /// Returns an iterator which yields the current iteration count as well
@@ -944,7 +940,7 @@ pub trait FallibleIterator {
         F: FnMut(Self::Error) -> B,
         Self: Sized,
     {
-        MapErr { it: self, f: f }
+        MapErr { it: self, f }
     }
 
     /// Returns an iterator which unwraps all of its elements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,37 +67,22 @@
 #![warn(missing_docs)]
 #![no_std]
 
-use core::cmp::{self, Ordering};
-use core::iter;
+use core::{
+    cmp::{self, Ordering},
+    iter,
+};
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-#[cfg_attr(test, macro_use)]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-mod imports {
-    pub use alloc::boxed::Box;
-    pub use alloc::collections::btree_map::BTreeMap;
-    pub use alloc::collections::btree_set::BTreeSet;
-    pub use alloc::vec::Vec;
-}
+#[cfg(feature = "alloc")]
+pub use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 
-#[cfg(feature = "std")]
-#[cfg_attr(test, macro_use)]
-extern crate std;
-
-#[cfg(feature = "std")]
-mod imports {
-    pub use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-    pub use std::hash::{BuildHasher, Hash};
-    pub use std::prelude::v1::*;
-}
-
-#[cfg(any(feature = "std", feature = "alloc"))]
-use crate::imports::*;
-
-#[cfg(any(feature = "std", feature = "alloc"))]
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod test;
 
 enum FoldStop<T, E> {
@@ -1000,7 +985,7 @@ impl<I: DoubleEndedFallibleIterator + ?Sized> DoubleEndedFallibleIterator for &m
     }
 }
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 impl<I: FallibleIterator + ?Sized> FallibleIterator for Box<I> {
     type Item = I::Item;
     type Error = I::Error;
@@ -1021,7 +1006,7 @@ impl<I: FallibleIterator + ?Sized> FallibleIterator for Box<I> {
     }
 }
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 impl<I: DoubleEndedFallibleIterator + ?Sized> DoubleEndedFallibleIterator for Box<I> {
     #[inline]
     fn next_back(&mut self) -> Result<Option<I::Item>, I::Error> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
-use core::iter;
-use core::ops::Range;
+use alloc::vec;
+use core::{iter, ops::Range};
 
 use super::{convert, FallibleIterator, Vec};
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
-use alloc::vec;
+use alloc::{vec, vec::Vec};
 use core::{iter, ops::Range};
 
-use super::{convert, FallibleIterator, Vec};
+use super::{convert, FallibleIterator};
 
 #[test]
 fn all() {
@@ -241,8 +241,7 @@ fn max_by_key() {
     // Exercise failure both on the first item, and later.
     assert_eq!(it.clone().max_by_key(|&i| Err::<i32, _>(i)), Err(0));
     assert_eq!(
-        it.clone()
-            .max_by_key(|&i| if i > 0 { Err(i) } else { Ok(-i) }),
+        it.max_by_key(|&i| if i > 0 { Err(i) } else { Ok(-i) }),
         Err(3)
     );
 }
@@ -266,8 +265,7 @@ fn min_by_key() {
     // Exercise failure both on the first item, and later.
     assert_eq!(it.clone().min_by_key(|&i| Err::<i32, _>(i)), Err(0));
     assert_eq!(
-        it.clone()
-            .min_by_key(|&i| if i > 0 { Err(i) } else { Ok(-i) }),
+        it.min_by_key(|&i| if i > 0 { Err(i) } else { Ok(-i) }),
         Err(3)
     );
 }
@@ -304,15 +302,14 @@ fn position() {
     assert_eq!(it.position(|n| Ok(n == 3)).unwrap(), Some(0));
     assert_eq!(it.position(|n| Ok(n == 5)).unwrap(), None);
 
-    let it = convert(vec![1, 2, 3, 4].into_iter().map(Ok::<i32, i32>));
+    let mut it = convert(vec![1, 2, 3, 4].into_iter().map(Ok::<i32, i32>));
     assert_eq!(
         it.clone()
             .position(|n| if n == 3 { Err(42) } else { Ok(n == 2) }),
         Ok(Some(1))
     );
     assert_eq!(
-        it.clone()
-            .position(|n| if n == 3 { Err(42) } else { Ok(n == 4) }),
+        it.position(|n| if n == 3 { Err(42) } else { Ok(n == 4) }),
         Err(42)
     );
 }
@@ -335,7 +332,7 @@ fn skip() {
     let it = convert(vec![1, 2, 3, 4].into_iter().map(Ok::<i32, ()>));
     assert_eq!(it.clone().skip(0).collect::<Vec<_>>(), Ok(vec![1, 2, 3, 4]));
     assert_eq!(it.clone().skip(2).collect::<Vec<_>>(), Ok(vec![3, 4]));
-    assert_eq!(it.clone().skip(4).collect::<Vec<_>>(), Ok(vec![]));
+    assert_eq!(it.skip(4).collect::<Vec<_>>(), Ok(vec![]));
 }
 
 #[test]
@@ -350,7 +347,7 @@ fn skip_while() {
         Ok(vec![3, 4, 1])
     );
     assert_eq!(
-        it.clone().skip_while(|x| Ok(*x < 5)).collect::<Vec<_>>(),
+        it.skip_while(|x| Ok(*x < 5)).collect::<Vec<_>>(),
         Ok(vec![])
     );
 }
@@ -384,7 +381,7 @@ fn take_while() {
         Ok(vec![0, 1])
     );
     assert_eq!(
-        it.clone().take_while(|x| Ok(*x < 4)).collect::<Vec<_>>(),
+        it.take_while(|x| Ok(*x < 4)).collect::<Vec<_>>(),
         Ok(vec![0, 1, 2, 3, 0])
     );
 }
@@ -411,7 +408,10 @@ fn flatten() {
 #[test]
 fn inspect() {
     let mut buf = vec![];
-    let it = convert(vec![0, 1, 2, 3].into_iter().map(Ok::<i32, ()>)).inspect(|v| Ok(buf.push(*v)));
+    let it = convert(vec![0, 1, 2, 3].into_iter().map(Ok::<i32, ()>)).inspect(|&v| {
+        buf.push(v);
+        Ok(())
+    });
     it.count().unwrap();
     assert_eq!(buf, vec![0, 1, 2, 3]);
 }
@@ -451,10 +451,7 @@ fn unzip() {
 #[test]
 fn cycle() {
     let it = convert(vec![0, 1, 2, 3].into_iter().map(Ok::<i32, ()>)).cycle();
-    assert_eq!(
-        it.take(6).clone().collect::<Vec<_>>(),
-        Ok(vec![0, 1, 2, 3, 0, 1])
-    );
+    assert_eq!(it.take(6).collect::<Vec<_>>(), Ok(vec![0, 1, 2, 3, 0, 1]));
 }
 
 #[test]


### PR DESCRIPTION
Hello there! Just wanted to send in a PR that cleans up the feature-gated imports for this crate. To make the review easier, I made sure to neatly separate each commit according to their purpose.

# `std` implies `alloc`
The first major change I did was to adjust the feature list so that `std` now implies `alloc`. That way, we no longer have to check the condition `any(feature = "std", feature = "alloc")` anymore.

```toml
[features]
default = ["std"]
alloc = []
std = ["alloc"] # `std` implies `alloc`
```

As much as possible, I imported from `core`. I only imported from the feature-gated `alloc` and `std` crates when absolutely necessary (and as a last resort).

# `std` not necessary?
After restructuring the imports and features, I noticed that many of the imported items were actually unused. Namely:

* `alloc::collections::{BTreeMap, BTreeSet}`
* `core::hash::{BuildHasher, Hash}`
* `std::collections::{HashMap, HashSet}`

In fact, the only item from `alloc` that the crate directly uses is `alloc::boxed::Box`.[^impl] All other imports from `alloc` and `std` are unused. I have thus taken the liberty in removing them.

[^impl]: The `Box` import was used to `impl` the `FallibleIterator` trait for boxed iterators (i.e. `Box<I: FallibleIterator>`.

But, this does introduce an interesting situation: the `std` feature is actually unused now! We can completely remove it from the crate's exposed `features`.

I'm not exactly sure why this is the case. The documentation mentions that the crate:

> ... provides implementations for `Box`, `Vec`, `BTreeMap`, and `BTreeSet` [when `alloc` is enabled]. If the `std` feature is enabled, this crate additionally provides implementations for `HashMap` and `HashSet`.

Nevertheless, I've removed the `std` feature because it is indeed unused. Implementing the missing features is beyond the scope of this PR. Future PRs may want to consider upholding that `std` implies `alloc` when `std` is re-introduced into the crate.

# Fixing some Clippy lints...
When the errors finally disappeared, I noticed a bunch of Clippy warnings. These have been addressed as well. Please see the aptly named commit message for the (rather mechanical) changes.

# Fixing some outdated doc-comments...
One of the doc-comments uses the now-removed `FromFallibleIterator` trait, which causes the example tests to fail. I've resolved this issue.

# Bumping the MSRV to `1.36`
See https://github.com/sfackler/rust-fallible-iterator/pull/26#issuecomment-1214379669.