### PR TITLE
Fix a test that has been broken since FromFallibleIterator was removed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1794,7 +1794,7 @@ where
 /// Creates an iterator from a fallible function generating values
 ///
 /// ```
-/// # use fallible_iterator::{from_fn, FromFallibleIterator, FallibleIterator};
+/// # use fallible_iterator::{from_fn, FallibleIterator};
 /// let mut count = 0;
 /// let counter = from_fn(move || {
 ///     // Increment our count. This is why we started at zero.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1791,7 +1791,7 @@ where
     }
 }
 
-/// Creates an iterator from a fallible function generating values
+/// Creates an iterator from a fallible function generating values.
 ///
 /// ```
 /// # use fallible_iterator::{from_fn, FallibleIterator};


### PR DESCRIPTION
I guess nobody's tried to run tests on this crate since then? Huh. In any case, all it took was removing the mention of the trait and the test passed again.