### PR TITLE
add wrapper for std::iter::Iterator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   stable:
     docker:
-    - image: rust:1.34.0
+    - image: rust:1.33.0
     environment:
       RUSTFLAGS: -D warnings
     working_directory: ~/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   stable:
     docker:
-    - image: rust:1.33.0
+    - image: rust:1.34.0
     environment:
       RUSTFLAGS: -D warnings
     working_directory: ~/build

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 #![no_std]
 
 use core::cmp::{self, Ordering};
+use core::convert::Infallible;
 use core::iter;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
@@ -2594,6 +2595,25 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (_, max) = self.0.size_hint();
         (0, max)
+    }
+}
+
+/// wrap std::iter::iterator into a (in)FallibleIterator
+pub struct IntoFallible<I>(I);
+
+impl<I: std::iter::Iterator<Item = T>, T> FallibleIterator for IntoFallible<I> {
+    type Item = T;
+
+    type Error = Infallible;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+       Ok(self.0.next())
+    }
+}
+
+impl<T, I: std::iter::Iterator<Item = T>> From<I> for IntoFallible<I> {
+    fn from(value: I) -> Self {
+        Self(value)
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 use core::iter;
 use core::ops::Range;
 
-use super::{convert, FallibleIterator, Vec};
+use super::{convert, FallibleIterator, Vec, IntoFallible};
 
 #[test]
 fn all() {
@@ -469,4 +469,10 @@ fn unwrap_panic() {
     let _ = convert(vec![Ok(0), Err(())].into_iter())
         .unwrap()
         .collect::<Vec<_>>();
+}
+
+#[test]
+fn wrap_std_iter_into_fallible() {
+    let it = IntoFallible::from(vec![0, 1, 2, 3].into_iter());
+    assert_eq!(it.collect::<Vec<_>>().unwrap(),vec![0,1,2,3]);
 }


### PR DESCRIPTION
Hey!
Thanks for this fantastic crates, I'm opening this MR because it already few times that I had to convert a `std::iter::Iterator` into a `FallibleIterator` (eg applying flatmap to a `Vec<FallibleIterator>`). It might be useful also for other dev that use this crate.