### PR TITLE
Restore std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ categories = ["algorithms", "no-std"]
 [features]
 default = ["alloc"]
 alloc = []
+# Legacy feature, no longer needed but retained for backwards compatibility.
+std = ["alloc"]


### PR DESCRIPTION
5bc90bd179441581ddf93b0e21a6c97600537750 removed this feature because it
is redundant with alloc, but features are part of the public API.
Restore this feature so that downstream crates that depend on
fallible-iterator/std can continue to work.
